### PR TITLE
Fix broken test, add support for tox and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - pypy
+install: python setup.py install
+before_script: pip install pytest
+script: py.test dotcloud

--- a/dotcloud/ui/tests/test_hello.py
+++ b/dotcloud/ui/tests/test_hello.py
@@ -1,5 +1,12 @@
-from dotcloud.cli2 import CLI
+import os
+
+import pytest
+
+from dotcloud.ui import CLI
+
 
 def test_hello():
-    CLI().run()
-    assert True
+    url = os.environ.get('DOTCLOUD_API_ENDPOINT', 'https://ws.dotcloud.com/1.0')
+    cli = CLI(endpoint=url)
+    with pytest.raises(SystemExit):
+        cli.run(['--version'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+commands = py.test {posargs:dotcloud}
+deps =
+    pytest


### PR DESCRIPTION
### Before:

```
$ py.test dotcloud
=================================================================================================================================================== test session starts ====================================================================================================================================================
platform darwin -- Python 2.7.6 -- py-1.4.20 -- pytest-2.5.2
collected 0 items / 1 errors

========================================================================================================================================================== ERRORS ==========================================================================================================================================================
_____________________________________________________________________________________________________________________________________ ERROR collecting dotcloud/ui/tests/test_hello.py _____________________________________________________________________________________________________________________________________
dotcloud/ui/tests/test_hello.py:1: in <module>
>   from dotcloud.cli2 import CLI
E   ImportError: No module named cli2
```

### After:

#### Passing Travis CI build:

https://travis-ci.org/msabramo/dotcloud-cli

#### Tox:

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  congratulations :)
```